### PR TITLE
Fix hydration of classes without properties

### DIFF
--- a/src/Hydration/HydrateUsingReflection.php
+++ b/src/Hydration/HydrateUsingReflection.php
@@ -35,6 +35,7 @@ class HydrateUsingReflection implements Hydrate
         $className = get_class($object);
 
         if (!isset($this->properties[$className])) {
+            $this->properties[$className] = [];
             foreach ((new \ReflectionObject($object))->getProperties() as $property) {
                 /** @var \ReflectionProperty $property */
                 $property->setAccessible(true);

--- a/test/Hydrate/Fixtures/ClassWithoutProperties.php
+++ b/test/Hydrate/Fixtures/ClassWithoutProperties.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BroadwaySerialization\Test\Hydrate\Fixtures;
+
+class ClassWithoutProperties
+{
+}

--- a/test/Hydrate/HydrateUsingReflectionTest.php
+++ b/test/Hydrate/HydrateUsingReflectionTest.php
@@ -3,6 +3,7 @@
 namespace BroadwaySerialization\Test\Hydrate;
 
 use BroadwaySerialization\Hydration\HydrateUsingReflection;
+use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithoutProperties;
 use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithPrivateProperties;
 
 class HydrateUsingReflectionTest extends \PHPUnit_Framework_TestCase
@@ -48,5 +49,18 @@ class HydrateUsingReflectionTest extends \PHPUnit_Framework_TestCase
         $hydrate->hydrate(['extra' => 'no problem', 'foo' => 'bar'], $object);
 
         $this->assertSame('bar', $object->foo());
+    }
+
+    /**
+     * @test
+     */
+    public function it_works_for_objects_without_properties()
+    {
+        $object = new ClassWithoutProperties();
+
+        $hydrate = new HydrateUsingReflection();
+
+        // This class doesn't have any property which should be no problem
+        $hydrate->hydrate([], $object);
     }
 }


### PR DESCRIPTION
This PR enables hydrating a class that does not have any properties. This could be useful when you have a `DayHasPassed` event. I encountered the bug while testing serialization of classes with inheritance (See #7).
