### PR TITLE
Closure variants for hydration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_script:
 
 script:
   - vendor/bin/phpunit
-  - vendor/bin/phpbench
+  - vendor/bin/phpbench run --report=default
+
 
 after_script:
   - vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ after_script:
   - vendor/bin/coveralls
 
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Reconstitution::reconstituteUsing(
 );
 ```
 
+Note that this package ships with different implementations of the hydrator. Depending on your setup and preferences, you can also use the `HydrateUsingClosure` class. The former generally performs better than the `HydrateUsingReflection`.
+
 ### Symfony
 
 If you're using Symfony, this can be managed for you automatically. Just register the 
@@ -99,3 +101,4 @@ If you're using Symfony, this can be managed for you automatically. Just registe
 
 When using this library, your personal performance will increase significantly. Of course, runtime performance will 
 be worse (not noticeably though, unless you're actually deserializing millions of objects).
+

--- a/src/Hydration/HydrateUsingClosure.php
+++ b/src/Hydration/HydrateUsingClosure.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BroadwaySerialization\Hydration;
+
+class HydrateUsingClosure implements Hydrate
+{
+    /** @var \Closure */
+    private $hydrator;
+
+    /**
+     * @var $cache $cache[FQCN][property] = true means property exists
+     */
+    private $cache = [];
+
+    /**
+     * Creates a closure which is to be bound to an instance
+     */
+    public function __construct()
+    {
+        $this->hydrator = function (array $data, array $props) {
+            foreach ($data as $key => $value) {
+                if (isset($props[$key])) {
+                    $this->{$key} = $value;
+                }
+            }
+        };
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hydrate(array $data, $object)
+    {
+        $class = get_class($object);
+        if (!isset($this->cache[$class])) {
+            $this->getProps($class);
+        }
+
+        $this->hydrator->call($object, $data, $this->cache[$class]);
+    }
+
+    /**
+     * @param $class
+     */
+    private function getProps($class)
+    {
+        $this->cache[$class] = [];
+        foreach ((new \ReflectionClass($class))->getProperties() as $property) {
+            $this->cache[$class][$property->getName()] = true;
+        }
+    }
+}

--- a/test/Hydrate/AbstractTestForHydration.php
+++ b/test/Hydrate/AbstractTestForHydration.php
@@ -1,0 +1,69 @@
+<?php namespace BroadwaySerialization\Test\Hydrate;
+
+use BroadwaySerialization\Hydration\Hydrate;
+use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithoutProperties;
+use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithPrivateProperties;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractTestForHydration extends TestCase
+{
+
+    /**
+     * @test
+     */
+    public function it_hydrates_an_object_with_private_properties()
+    {
+        $hydrate = $this->getHydrator();
+        $object = new ClassWithPrivateProperties();
+        $hydrate->hydrate(['foo' => 'bar'], $object);
+
+        $this->assertSame('bar', $object->foo());
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_keys_that_are_not_defined_in_the_data_array()
+    {
+        $hydrate = $this->getHydrator();
+        $object = new ClassWithPrivateProperties();
+
+        // 'foo' is not defined, which should be no problem
+        $hydrate->hydrate([], $object);
+
+        $this->assertSame(null, $object->foo());
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_extra_keys_in_the_data_array()
+    {
+        $hydrate = $this->getHydrator();
+        $object = new ClassWithPrivateProperties();
+
+        // 'extra' is not a property, which should be no problem
+        $hydrate->hydrate(['extra' => 'no problem', 'foo' => 'bar'], $object);
+
+        $this->assertSame('bar', $object->foo());
+    }
+
+    /**
+     * @test
+     */
+    public function it_works_for_objects_without_properties()
+    {
+        $hydrate = $this->getHydrator();
+        $object = new ClassWithoutProperties();
+
+        // This class doesn't have any property which should be no problem
+        $hydrate->hydrate([], $object);
+
+        $this->assertTrue(true); // to prevent a strict warning
+    }
+
+    /**
+     * @return Hydrate
+     */
+    abstract protected function getHydrator();
+}

--- a/test/Hydrate/HydrateUsingClosureTest.php
+++ b/test/Hydrate/HydrateUsingClosureTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BroadwaySerialization\Test\Hydrate;
+
+use BroadwaySerialization\Hydration\HydrateUsingClosure;
+
+class HydrateUsingClosureTest extends AbstractTestForHydration
+{
+    protected function getHydrator()
+    {
+        return new HydrateUsingClosure();
+    }
+}

--- a/test/Hydrate/HydrateUsingReflectionTest.php
+++ b/test/Hydrate/HydrateUsingReflectionTest.php
@@ -4,67 +4,11 @@ declare(strict_types = 1);
 namespace BroadwaySerialization\Test\Hydrate;
 
 use BroadwaySerialization\Hydration\HydrateUsingReflection;
-use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithoutProperties;
-use BroadwaySerialization\Test\Hydrate\Fixtures\ClassWithPrivateProperties;
-use PHPUnit\Framework\TestCase;
 
-final class HydrateUsingReflectionTest extends TestCase
+final class HydrateUsingReflectionTest extends AbstractTestForHydration
 {
-    /**
-     * @test
-     */
-    public function it_hydrates_an_object_with_private_properties()
+    protected function getHydrator()
     {
-        $object = new ClassWithPrivateProperties();
-
-        $hydrate = new HydrateUsingReflection();
-        $hydrate->hydrate(['foo' => 'bar'], $object);
-
-        $this->assertSame('bar', $object->foo());
-    }
-
-    /**
-     * @test
-     */
-    public function it_ignores_keys_that_are_not_defined_in_the_data_array()
-    {
-        $object = new ClassWithPrivateProperties();
-
-        $hydrate = new HydrateUsingReflection();
-
-        // 'foo' is not defined, which should be no problem
-        $hydrate->hydrate([], $object);
-
-        $this->assertSame(null, $object->foo());
-    }
-
-    /**
-     * @test
-     */
-    public function it_ignores_extra_keys_in_the_data_array()
-    {
-        $object = new ClassWithPrivateProperties();
-
-        $hydrate = new HydrateUsingReflection();
-
-        // 'extra' is not a property, which should be no problem
-        $hydrate->hydrate(['extra' => 'no problem', 'foo' => 'bar'], $object);
-
-        $this->assertSame('bar', $object->foo());
-    }
-
-    /**
-     * @test
-     */
-    public function it_works_for_objects_without_properties()
-    {
-        $object = new ClassWithoutProperties();
-
-        $hydrate = new HydrateUsingReflection();
-
-        // This class doesn't have any property which should be no problem
-        $hydrate->hydrate([], $object);
-
-        $this->assertTrue(true); // to prevent a strict warning
+        return new HydrateUsingReflection();
     }
 }

--- a/test/Performance/ReconstitutionBench.php
+++ b/test/Performance/ReconstitutionBench.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace BroadwaySerialization\Test\Performance;
 
+use BroadwaySerialization\Hydration\HydrateUsingClosure;
 use BroadwaySerialization\Hydration\HydrateUsingReflection;
 use BroadwaySerialization\Reconstitution\ReconstituteUsingInstantiatorAndHydrator;
 use BroadwaySerialization\Reconstitution\Reconstitution;
@@ -32,20 +33,22 @@ final class ReconstitutionBench
         ]
     ];
 
-    public function setup()
+
+    public function setupReconstituteUsingInstantiatorAndReflection()
     {
         $reconstitute = new ReconstituteUsingInstantiatorAndHydrator(new Instantiator(), new HydrateUsingReflection());
+        Reconstitution::reconstituteUsing($reconstitute);
+    }
 
-        // test run, for calibration
-        $reconstitute->objectFrom(SerializableClassUsingTrait::class, []);
-        $reconstitute->objectFrom(SomeOtherSerializableClassUsingTrait::class, []);
-
+    public function setupReconstituteUsingInstantiatorAndClosure()
+    {
+        $reconstitute = new ReconstituteUsingInstantiatorAndHydrator(new Instantiator(), new HydrateUsingClosure());
         Reconstitution::reconstituteUsing($reconstitute);
     }
 
     /**
      * @Warmup(10)
-     * @Revs(100000)
+     * @Revs(1000)
      * @Groups({"traditional"})
      */
     public function benchDeserializeTraditionalObject()
@@ -55,12 +58,24 @@ final class ReconstitutionBench
 
     /**
      * @Warmup(10)
-     * @Revs(100000)
+     * @Revs(1000)
      * @Groups({"trait"})
-     * @BeforeMethods({"setup"})
+     * @BeforeMethods({"setupReconstituteUsingInstantiatorAndReflection"})
      */
-    public function benchDeserializeObjectUsingTrait()
+    public function benchDeserializeObjectUsingReflection()
+    {
+        SerializableClassUsingTrait::deserialize($this->deserializationData);
+    }
+
+    /**
+     * @Warmup(10)
+     * @Revs(1000)
+     * @Groups({"trait"})
+     * @BeforeMethods({"setupReconstituteUsingInstantiatorAndClosure"})
+     */
+    public function benchDeserializeObjectUsingClosure()
     {
         SerializableClassUsingTrait::deserialize($this->deserializationData);
     }
 }
+    

--- a/test/Performance/SerializationBench.php
+++ b/test/Performance/SerializationBench.php
@@ -4,10 +4,6 @@ declare(strict_types = 1);
 namespace BroadwaySerialization\Test\Performance;
 
 use Broadway\Serializer\Serializable;
-use BroadwaySerialization\Hydration\HydrateUsingReflection;
-use BroadwaySerialization\Reconstitution\ReconstituteUsingInstantiatorAndHydrator;
-use BroadwaySerialization\Reconstitution\Reconstitution;
-use Doctrine\Instantiator\Instantiator;
 use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
 use PhpBench\Benchmark\Metadata\Annotations\Groups;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
@@ -31,20 +27,9 @@ final class BenchSerialization
         $this->serializableClassUsingTrait = new SerializableClassUsingTrait();
     }
 
-    public function setupReconstitute()
-    {
-        $reconstitute = new ReconstituteUsingInstantiatorAndHydrator(new Instantiator(), new HydrateUsingReflection());
-
-        // test run, for calibration
-        $reconstitute->objectFrom(SerializableClassUsingTrait::class, []);
-        $reconstitute->objectFrom(SomeOtherSerializableClassUsingTrait::class, []);
-
-        Reconstitution::reconstituteUsing($reconstitute);
-    }
-
     /**
      * @Warmup(10)
-     * @Revs(100000)
+     * @Revs(1000)
      * @Groups({"traditional"})
      * @BeforeMethods({"setup"})
      */
@@ -55,9 +40,9 @@ final class BenchSerialization
 
     /**
      * @Warmup(10)
-     * @Revs(100000)
+     * @Revs(1000)
      * @Groups({"trait"})
-     * @BeforeMethods({"setup","setupReconstitute"})
+     * @BeforeMethods({"setup"})
      */
     public function benchSerializeObjectWithOnlyScalarPropertiesWithTrait()
     {

--- a/test/Reconstitution/ReconstitutionTest.php
+++ b/test/Reconstitution/ReconstitutionTest.php
@@ -6,6 +6,7 @@ namespace BroadwaySerialization\Test\Reconstitution;
 use BroadwaySerialization\Reconstitution\Reconstitute;
 use BroadwaySerialization\Reconstitution\Reconstitution;
 use PHPUnit\Framework\TestCase;
+use LogicException;
 
 final class ReconstitutionTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class ReconstitutionTest extends TestCase
      */
     public function it_gives_a_nice_warning_if_no_reconstitute_object_was_provided()
     {
-        $this->expectException(\LogicException::class);
+        $this->expectException(LogicException::class);
 
         Reconstitution::reconstitute();
     }


### PR DESCRIPTION
This PR adds (among some minor details) two new Hydrate implementations, which exploit closure binding via `Closure::bindTo` and `Closure::call` (PHP7).
- Since PHP 5.5 is EOL, I removed support for it, so I could easily upgrade to PHPUnit 5 and mark PHP7 specific tests as skipped
- An abstract test for implementations of Hydrate is added
- Some benchmarks are added
- Travis is configured to run the PHPBench tests (using fewer iterations)

If support for PHP 5.5 must be provided, I'm of course willing to update this PR. The closure trick works on PHP 5.5 as well.
