### PR TITLE
Updated: Use static when calling deserializationCallback() 

### DIFF
--- a/src/Serialization/AutoSerializable.php
+++ b/src/Serialization/AutoSerializable.php
@@ -22,7 +22,7 @@ trait AutoSerializable
     {
         return Reconstitution::reconstitute()->objectFrom(
             get_called_class(),
-            RecursiveSerializer::deserialize($data, self::deserializationCallbacks())
+            RecursiveSerializer::deserialize($data, static::deserializationCallbacks())
         );
     }
 

--- a/test/Serialization/Fixtures/SerializableAbstractClass.php
+++ b/test/Serialization/Fixtures/SerializableAbstractClass.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BroadwaySerialization\Test\Serialization\Fixtures;
 
-use Broadway\Serializer\SerializableInterface;
-use BroadwaySerialization\Serialization\Serializable;
+use Broadway\Serializer\Serializable;
+use BroadwaySerialization\Serialization\AutoSerializable;
 
-abstract class SerializableAbstractClass implements SerializableInterface
+abstract class SerializableAbstractClass implements Serializable
 {
-    use Serializable;
+    use AutoSerializable;
 
     protected $foo;
 
@@ -19,7 +21,7 @@ abstract class SerializableAbstractClass implements SerializableInterface
     protected static function deserializationCallbacks()
     {
         return [
-            'foo' => ['BroadwaySerialization\Test\Serialization\Fixtures\TraditionalSerializableObject', 'deserialize']
+            'foo' => [TraditionalSerializableObject::class, 'deserialize']
         ];
     }
 }

--- a/test/Serialization/Fixtures/SerializableAbstractClass.php
+++ b/test/Serialization/Fixtures/SerializableAbstractClass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+use Broadway\Serializer\SerializableInterface;
+use BroadwaySerialization\Serialization\Serializable;
+
+abstract class SerializableAbstractClass implements SerializableInterface
+{
+    use Serializable;
+
+    protected $foo;
+
+    public function __construct(TraditionalSerializableObject $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    protected static function deserializationCallbacks()
+    {
+        return [
+            'foo' => ['BroadwaySerialization\Test\Serialization\Fixtures\TraditionalSerializableObject', 'deserialize']
+        ];
+    }
+}

--- a/test/Serialization/Fixtures/SerializableAbstractClassWithPrivates.php
+++ b/test/Serialization/Fixtures/SerializableAbstractClassWithPrivates.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BroadwaySerialization\Test\Serialization\Fixtures;
 
-use Broadway\Serializer\SerializableInterface;
-use BroadwaySerialization\Serialization\Serializable;
+use Broadway\Serializer\Serializable;
+use BroadwaySerialization\Serialization\AutoSerializable;
 
-abstract class SerializableAbstractClassWithPrivates implements SerializableInterface
+abstract class SerializableAbstractClassWithPrivates implements Serializable
 {
-    use Serializable;
+    use AutoSerializable;
 
     private $foo;
 

--- a/test/Serialization/Fixtures/SerializableAbstractClassWithPrivates.php
+++ b/test/Serialization/Fixtures/SerializableAbstractClassWithPrivates.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+use Broadway\Serializer\SerializableInterface;
+use BroadwaySerialization\Serialization\Serializable;
+
+abstract class SerializableAbstractClassWithPrivates implements SerializableInterface
+{
+    use Serializable;
+
+    private $foo;
+
+    public function __construct($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function foo()
+    {
+        return $this->foo;
+    }
+}

--- a/test/Serialization/Fixtures/SerializableChildOfClassWithPrivates.php
+++ b/test/Serialization/Fixtures/SerializableChildOfClassWithPrivates.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+class SerializableChildOfClassWithPrivates extends SerializableAbstractClassWithPrivates
+{
+}

--- a/test/Serialization/Fixtures/SerializableChildWithPrivates.php
+++ b/test/Serialization/Fixtures/SerializableChildWithPrivates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+class SerializableChildWithPrivates extends SerializableAbstractClass
+{
+    private $baz;
+
+    public function __construct(TraditionalSerializableObject $foo, $baz)
+    {
+        parent::__construct($foo);
+        $this->baz = $baz;
+    }
+
+    public function baz()
+    {
+        return $this->baz;
+    }
+}

--- a/test/Serialization/Fixtures/SerializableObjectWithParent.php
+++ b/test/Serialization/Fixtures/SerializableObjectWithParent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+class SerializableObjectWithParent extends SerializableAbstractClass
+{
+    protected $bar;
+    protected $baz;
+
+    public function __construct(TraditionalSerializableObject $foo, TraditionalSerializableObject $baz, $bar)
+    {
+        parent::__construct($foo);
+        $this->baz = $baz;
+        $this->bar = $bar;
+    }
+
+    protected static function deserializationCallbacks()
+    {
+        return array_merge(
+            parent::deserializationCallbacks(),
+            [
+                'baz' => ['BroadwaySerialization\Test\Serialization\Fixtures\TraditionalSerializableObject', 'deserialize']
+            ]
+        );
+    }
+}

--- a/test/Serialization/Fixtures/SerializableSimpleObjectWithParent.php
+++ b/test/Serialization/Fixtures/SerializableSimpleObjectWithParent.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace BroadwaySerialization\Test\Serialization\Fixtures;
+
+class SerializableSimpleObjectWithParent extends SerializableAbstractClass
+{
+    protected $bar;
+
+    public function __construct(TraditionalSerializableObject $foo, $bar)
+    {
+        parent::__construct($foo);
+        $this->bar = $bar;
+    }
+}

--- a/test/Serialization/SerializableTest.php
+++ b/test/Serialization/SerializableTest.php
@@ -6,8 +6,14 @@ namespace BroadwaySerialization\Test\Serialization;
 use BroadwaySerialization\Hydration\HydrateUsingReflection;
 use BroadwaySerialization\Reconstitution\ReconstituteUsingInstantiatorAndHydrator;
 use BroadwaySerialization\Reconstitution\Reconstitution;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableAbstractClass;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableAbstractClassWithPrivates;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableChildOfClassWithPrivates;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableChildWithPrivates;
 use BroadwaySerialization\Test\Serialization\Fixtures\SerializableObjectUsingTrait;
 use BroadwaySerialization\Test\Serialization\Fixtures\SerializableObjectWithNoCallbacks;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableObjectWithParent;
+use BroadwaySerialization\Test\Serialization\Fixtures\SerializableSimpleObjectWithParent;
 use BroadwaySerialization\Test\Serialization\Fixtures\TraditionalSerializableObject;
 use Doctrine\Instantiator\Instantiator;
 use PHPUnit\Framework\TestCase;
@@ -55,5 +61,89 @@ final class SerializableTest extends TestCase
         $reconstitutedInstance = SerializableObjectWithNoCallbacks::deserialize($data);
 
         $this->assertEquals($originalObject, $reconstitutedInstance);
+    }
+
+    /**
+     * @test
+     */
+    public function it_serializes_objects_inheriting_from_a_serializable_object()
+    {
+        $originalObject = new SerializableSimpleObjectWithParent(
+            new TraditionalSerializableObject('baz'),
+            42
+        );
+
+        $data = $originalObject->serialize();
+
+        $reconstitutedInstance = SerializableSimpleObjectWithParent::deserialize($data);
+
+        $this->assertEquals($originalObject, $reconstitutedInstance);
+    }
+
+    /**
+     * @test
+     */
+    public function it_uses_the_callbacks_of_a_child_class()
+    {
+        $originalObject = new SerializableObjectWithParent(
+            new TraditionalSerializableObject('foo'),
+            new TraditionalSerializableObject('baz'),
+            42
+        );
+
+        $data = $originalObject->serialize();
+        $reconstitutedInstance = SerializableObjectWithParent::deserialize($data);
+
+        $this->assertEquals($originalObject, $reconstitutedInstance);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_serialize_private_properties_of_a_child_class()
+    {
+        $originalObject = new SerializableChildWithPrivates(
+            // Protected property foo of parent
+            new TraditionalSerializableObject('foo'),
+            // 42 is the private property "baz"
+            42
+        );
+
+        $data = $originalObject->serialize();
+        $reconstitutedInstance = SerializableChildWithPrivates::deserialize($data);
+
+        // Check that the private property hasn't been serialized correctly
+        $this->assertArrayNotHasKey("baz", $data);
+
+        // As a result the original object and reconstituted object are not equal
+        $this->assertNotEquals(
+            $originalObject->baz(),
+            $reconstitutedInstance->baz(),
+            "Serializing private properties of a child class is not (yet) supported"
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_deserialize_private_properties_of_a_parent_class()
+    {
+        $originalObject = new SerializableChildOfClassWithPrivates(
+            // private property 'foo' of parent
+            'foo'
+        );
+
+        $data = $originalObject->serialize();
+        $reconstitutedInstance = SerializableChildOfClassWithPrivates::deserialize($data);
+
+        // Serializing private properties works
+        $this->assertArrayHasKey('foo', $data);
+
+        // Deserializing a private property of a parent class does not work
+        $this->assertNotEquals(
+            $originalObject->foo(),
+            $reconstitutedInstance->foo(),
+            "Serializing private properties of a parent class is not (yet) supported"
+        );
     }
 }


### PR DESCRIPTION
An old [PR](https://github.com/matthiasnoback/broadway-serialization/pull/7) from @MarkRedeman has been rebased on latest master.

@matthiasnoback This is both a proof of a problem and an actual fix. I'd very much like to see this merged.